### PR TITLE
Added missing nx_azure_iot_json_reader_token_uint32_get() function

### DIFF
--- a/addons/azure_iot/nx_azure_iot_json_reader.c
+++ b/addons/azure_iot/nx_azure_iot_json_reader.c
@@ -208,6 +208,22 @@ UINT nx_azure_iot_json_reader_token_int32_get(NX_AZURE_IOT_JSON_READER *reader_p
     return(NX_AZURE_IOT_SUCCESS);
 }
 
+UINT nx_azure_iot_json_reader_token_uint32_get(NX_AZURE_IOT_JSON_READER *reader_ptr, 
+                                               uint32_t *value_ptr)
+{
+    if ((reader_ptr == NX_NULL) || (value_ptr == NX_NULL))
+    {
+        return (NX_AZURE_IOT_INVALID_PARAMETER);
+    }
+
+    if (az_result_failed(az_json_token_get_uint32(&(reader_ptr->json_reader.token), value_ptr)))
+    {
+        return (NX_AZURE_IOT_SDK_CORE_ERROR);
+    }
+
+    return (NX_AZURE_IOT_SUCCESS);
+}
+
 UINT  nx_azure_iot_json_reader_token_double_get(NX_AZURE_IOT_JSON_READER *reader_ptr,
                                                 double *value_ptr)
 {

--- a/addons/azure_iot/nx_azure_iot_json_reader.h
+++ b/addons/azure_iot/nx_azure_iot_json_reader.h
@@ -149,6 +149,18 @@ UINT nx_azure_iot_json_reader_token_int32_get(NX_AZURE_IOT_JSON_READER *reader_p
                                               int32_t *value_ptr);
 
 /**
+ * @brief Gets the JSON token's number as a 32-bit unsigned integer.
+ *
+ * @param[in] reader_ptr A pointer to an #NX_AZURE_IOT_JSON_READER instance.
+ * @param[out] value_ptr A pointer to a variable to receive the value.
+ *
+ * @return An `UINT` value indicating the result of the operation.
+ * @retval #NX_AZURE_IOT_SUCCESS The number is returned.
+ */
+UINT nx_azure_iot_json_reader_token_uint32_get(NX_AZURE_IOT_JSON_READER *reader_ptr, 
+                                               uint32_t *value_ptr);
+
+/**
  * @brief Gets the JSON token's number as a `double`.
  *
  * @param[in] reader_ptr A pointer to an #NX_AZURE_IOT_JSON_READER instance.


### PR DESCRIPTION
Added missing `nx_azure_iot_json_reader_token_uint32_get()` function to read unsigned 32-bit JSON values, for example 4294967295.

The NetX JSON API currently provides the API `nx_azure_iot_json_reader_token_int32_get()` to read signed 32-bit values but no corresponding function for unsigned values. 

This PR exposes the underlaying `az_json_token_get_uint32()` method to NetX.
