### PR TITLE
Patch for 6.1.11b

### DIFF
--- a/crypto_libraries/src/nx_crypto_rsa.c
+++ b/crypto_libraries/src/nx_crypto_rsa.c
@@ -28,7 +28,7 @@
 /*  FUNCTION                                               RELEASE        */
 /*                                                                        */
 /*    _nx_crypto_rsa_operation                            PORTABLE C      */
-/*                                                           6.1          */
+/*                                                           6.1.11b      */
 /*  AUTHOR                                                                */
 /*                                                                        */
 /*    Timothy Stapko, Microsoft Corporation                               */
@@ -85,6 +85,9 @@
 /*  05-19-2020     Timothy Stapko           Initial Version 6.0           */
 /*  09-30-2020     Timothy Stapko           Modified comment(s),          */
 /*                                            resulting in version 6.1    */
+/*  02-03-2023     Yanwu Cai                Modified comment(s), aligned  */
+/*                                            buffer size of huge number, */
+/*                                            resulting in version 6.1.11b*/
 /*                                                                        */
 /**************************************************************************/
 NX_CRYPTO_KEEP UINT  _nx_crypto_rsa_operation(const UCHAR *exponent, UINT exponent_length, const UCHAR *modulus, UINT modulus_length,
@@ -92,7 +95,7 @@ NX_CRYPTO_KEEP UINT  _nx_crypto_rsa_operation(const UCHAR *exponent, UINT expone
                                               const UCHAR *input, UINT input_length, UCHAR *output,
                                               USHORT *scratch_buf_ptr, UINT scratch_buf_length)
 {
-UCHAR                *scratch;
+HN_UBASE             *scratch;
 UINT                  mod_length;
 NX_CRYPTO_HUGE_NUMBER modulus_hn, exponent_hn, input_hn, output_hn, p_hn, q_hn;
 
@@ -100,27 +103,19 @@ NX_CRYPTO_HUGE_NUMBER modulus_hn, exponent_hn, input_hn, output_hn, p_hn, q_hn;
 
     /* The RSA operation is reversible so both encryption and decryption can be done with the same operation. */
     /* Local pointer for pointer arithmetic. */
-    scratch = (UCHAR *)scratch_buf_ptr;
+    scratch = (HN_UBASE*)scratch_buf_ptr;
 
     /* Set up each of the buffers - point into the scratch buffer at increments of the DH buffer size. */
-    modulus_hn.nx_crypto_huge_number_data = (HN_UBASE *)scratch;
-    scratch += modulus_length;
-    modulus_hn.nx_crypto_huge_buffer_size = modulus_length;
+    NX_CRYPTO_HUGE_NUMBER_INITIALIZE(&modulus_hn, scratch, modulus_length);
 
     /* Input buffer(and scratch). */
-    input_hn.nx_crypto_huge_number_data = (HN_UBASE *)scratch;
-    scratch += modulus_length;
-    input_hn.nx_crypto_huge_buffer_size = modulus_length;
+    NX_CRYPTO_HUGE_NUMBER_INITIALIZE(&input_hn, scratch, modulus_length);
 
     /* Exponent  buffer (and scratch). */
-    exponent_hn.nx_crypto_huge_number_data = (HN_UBASE *)scratch;
-    scratch += modulus_length;
-    exponent_hn.nx_crypto_huge_buffer_size = modulus_length;
+    NX_CRYPTO_HUGE_NUMBER_INITIALIZE(&exponent_hn, scratch, modulus_length);
 
     /* Output buffer (and scratch). */
-    output_hn.nx_crypto_huge_number_data = (HN_UBASE *)scratch;
-    scratch += modulus_length * 2;
-    output_hn.nx_crypto_huge_buffer_size = modulus_length * 2;
+    NX_CRYPTO_HUGE_NUMBER_INITIALIZE(&output_hn, scratch, modulus_length << 1);
 
     /* Copy the exponent from the caller's buffer. */
     _nx_crypto_huge_number_setup(&exponent_hn, exponent, exponent_length);
@@ -134,13 +129,9 @@ NX_CRYPTO_HUGE_NUMBER modulus_hn, exponent_hn, input_hn, output_hn, p_hn, q_hn;
     if (p && q)
     {
 
-        p_hn.nx_crypto_huge_number_data = (HN_UBASE *)scratch;
-        scratch += (modulus_length >> 1);
-        p_hn.nx_crypto_huge_buffer_size = (modulus_length >> 1);
+        NX_CRYPTO_HUGE_NUMBER_INITIALIZE(&p_hn, scratch, modulus_length >> 1);
 
-        q_hn.nx_crypto_huge_number_data = (HN_UBASE *)scratch;
-        scratch += (modulus_length >> 1);
-        q_hn.nx_crypto_huge_buffer_size = (modulus_length >> 1);
+        NX_CRYPTO_HUGE_NUMBER_INITIALIZE(&q_hn, scratch, modulus_length >> 1);
 
         /* Copy the prime p and q from the caller's buffer. */
         _nx_crypto_huge_number_setup(&p_hn, p, p_length);
@@ -151,7 +142,7 @@ NX_CRYPTO_HUGE_NUMBER modulus_hn, exponent_hn, input_hn, output_hn, p_hn, q_hn;
            where the "**" denotes exponentiation. */
         _nx_crypto_huge_number_crt_power_modulus(&input_hn, &exponent_hn, &p_hn, &q_hn,
                                                  &modulus_hn, &output_hn,
-                                                 (HN_UBASE *)scratch);
+                                                 scratch);
     }
     else
     {
@@ -160,7 +151,7 @@ NX_CRYPTO_HUGE_NUMBER modulus_hn, exponent_hn, input_hn, output_hn, p_hn, q_hn;
            The actual calculation is "shared_secret = (public_key**private_key) % modulus"
            where the "**" denotes exponentiation. */
         _nx_crypto_huge_number_mont_power_modulus(&input_hn, &exponent_hn, &modulus_hn,
-                                                  &output_hn, (HN_UBASE *)scratch);
+                                                  &output_hn, scratch);
     }
 
     /* Copy the shared secret into the return buffer. */

--- a/nx_secure/src/nx_secure_tls_1_3_client_handshake.c
+++ b/nx_secure/src/nx_secure_tls_1_3_client_handshake.c
@@ -30,7 +30,7 @@
 /*  FUNCTION                                               RELEASE        */
 /*                                                                        */
 /*    _nx_secure_tls_1_3_client_handshake                 PORTABLE C      */
-/*                                                           6.1.11a      */
+/*                                                           6.1.11b      */
 /*  AUTHOR                                                                */
 /*                                                                        */
 /*    Timothy Stapko, Microsoft Corporation                               */
@@ -120,6 +120,9 @@
 /*                                            updated alert message for   */
 /*                                            downgrade protection,       */
 /*                                            resulting in version 6.1.11a*/
+/*  02-03-2023     Tiejun Zhou              Modified comment(s), and      */
+/*                                            corrected metadata cleanup, */
+/*                                            resulting in version 6.1.11b*/
 /*                                                                        */
 /**************************************************************************/
 
@@ -357,13 +360,6 @@ const UCHAR    *server_random;
 
             /* Update the transcript hash with the Finished.  */
             _nx_secure_tls_handshake_hash_update(tls_session, packet_start, message_length + header_bytes);
-
-            /* For client, cleanup hash handler after received the finished message from server. */
-            method_ptr = tls_session -> nx_secure_tls_crypto_table -> nx_secure_tls_handshake_hash_sha256_method;
-            if (method_ptr -> nx_crypto_cleanup != NX_NULL)
-            {
-                status = method_ptr -> nx_crypto_cleanup(tls_session -> nx_secure_tls_handshake_hash.nx_secure_tls_handshake_hash_sha256_metadata);
-            }
             break;
         case NX_SECURE_TLS_CERTIFICATE_VERIFY:
             /* Handle server-sent certificate verify. */
@@ -678,6 +674,12 @@ const UCHAR    *server_random;
                 break;
             }
 
+            /* For client, cleanup hash handler after sent the finished message to server. */
+            method_ptr = tls_session -> nx_secure_tls_crypto_table -> nx_secure_tls_handshake_hash_sha256_method;
+            if (method_ptr -> nx_crypto_cleanup != NX_NULL)
+            {
+                status = method_ptr -> nx_crypto_cleanup(tls_session -> nx_secure_tls_handshake_hash.nx_secure_tls_handshake_hash_sha256_metadata);
+            }
 
             break;
 /*      Cases not handled in TLS 1.3 (for reference):

--- a/nx_secure/src/nx_secure_tls_1_3_finished_hash_generate.c
+++ b/nx_secure/src/nx_secure_tls_1_3_finished_hash_generate.c
@@ -31,7 +31,7 @@
 /*  FUNCTION                                               RELEASE        */
 /*                                                                        */
 /*    _nx_secure_tls_1_3_finished_hash_generate           PORTABLE C      */
-/*                                                           6.1          */
+/*                                                           6.1.11b      */
 /*  AUTHOR                                                                */
 /*                                                                        */
 /*    Timothy Stapko, Microsoft Corporation                               */
@@ -72,6 +72,9 @@
 /*  05-19-2020     Timothy Stapko           Initial Version 6.0           */
 /*  09-30-2020     Timothy Stapko           Modified comment(s),          */
 /*                                            resulting in version 6.1    */
+/*  02-03-2023     Tiejun Zhou              Modified comment(s), and      */
+/*                                            corrected hash cleanup,     */
+/*                                            resulting in version 6.1.11b*/
 /*                                                                        */
 /**************************************************************************/
 #if (NX_SECURE_TLS_TLS_1_3_ENABLED)
@@ -251,11 +254,6 @@ NX_SECURE_TLS_KEY_SECRETS *secrets;
     {
         return(NX_SECURE_TLS_MISSING_CRYPTO_ROUTINE);
     }
-
-
-#ifdef NX_SECURE_KEY_CLEAR
-    NX_SECURE_MEMSET(finished_hash, 0, *hash_size);
-#endif /* NX_SECURE_KEY_CLEAR  */
 
     return(NX_SUCCESS);
 }

--- a/nx_secure/src/nx_secure_tls_process_finished.c
+++ b/nx_secure/src/nx_secure_tls_process_finished.c
@@ -31,7 +31,7 @@ static UCHAR generated_hash[NX_SECURE_TLS_MAX_HASH_SIZE];
 /*  FUNCTION                                               RELEASE        */
 /*                                                                        */
 /*    _nx_secure_tls_process_finished                     PORTABLE C      */
-/*                                                           6.1          */
+/*                                                           6.1.11b      */
 /*  AUTHOR                                                                */
 /*                                                                        */
 /*    Timothy Stapko, Microsoft Corporation                               */
@@ -74,6 +74,9 @@ static UCHAR generated_hash[NX_SECURE_TLS_MAX_HASH_SIZE];
 /*                                            verified memcpy use cases,  */
 /*                                            fixed renegotiation bug,    */
 /*                                            resulting in version 6.1    */
+/*  02-03-2023     Tiejun Zhou              Modified comment(s), and      */
+/*                                            corrected hash cleanup,     */
+/*                                            resulting in version 6.1.11b*/
 /*                                                                        */
 /**************************************************************************/
 UINT _nx_secure_tls_process_finished(NX_SECURE_TLS_SESSION *tls_session, UCHAR *packet_buffer,
@@ -107,9 +110,13 @@ UINT              is_server;
         else
         {
             
-            /* Compare to see if the Finished hash matches the recevied hash. */
+            /* Compare to see if the Finished hash matches the received hash. */
             compare_result = (UINT)NX_SECURE_MEMCMP(generated_hash, packet_buffer, hash_size);
         }
+
+#ifdef NX_SECURE_KEY_CLEAR
+        NX_SECURE_MEMSET(generated_hash, 0, sizeof(generated_hash));
+#endif /* NX_SECURE_KEY_CLEAR  */
     }
     else
 #endif
@@ -160,7 +167,7 @@ UINT              is_server;
         NX_SECURE_MEMCPY(tls_session -> nx_secure_tls_remote_verify_data, generated_hash, NX_SECURE_TLS_FINISHED_HASH_SIZE); /* Use case of memcpy is verified. */
 #endif /* NX_SECURE_TLS_DISABLE_SECURE_RENEGOTIATION */
 
-        /* The finished verify data is always 12 bytes (*except for SSLv3) - compare to see if the Finished hash matches the recevied hash. */
+        /* The finished verify data is always 12 bytes (*except for SSLv3) - compare to see if the Finished hash matches the received hash. */
         compare_result = (UINT)NX_SECURE_MEMCMP(generated_hash, packet_buffer, NX_SECURE_TLS_FINISHED_HASH_SIZE);
     }
 

--- a/nx_secure/src/nx_secure_tls_process_record.c
+++ b/nx_secure/src/nx_secure_tls_process_record.c
@@ -31,7 +31,7 @@ static VOID _nx_secure_tls_packet_trim(NX_PACKET *packet_ptr);
 /*  FUNCTION                                               RELEASE        */
 /*                                                                        */
 /*    _nx_secure_tls_process_record                       PORTABLE C      */
-/*                                                           6.1.11a      */
+/*                                                           6.1.11b      */
 /*  AUTHOR                                                                */
 /*                                                                        */
 /*    Timothy Stapko, Microsoft Corporation                               */
@@ -100,6 +100,9 @@ static VOID _nx_secure_tls_packet_trim(NX_PACKET *packet_ptr);
 /*  07-19-2022     Yuxin Zhou               Modified comment(s), and      */
 /*                                            checked seq number overflow,*/
 /*                                            resulting in version 6.1.11a*/
+/*  02-03-2023     Tiejun Zhou              Modified comment(s), and      */
+/*                                            corrected data cleanup,     */
+/*                                            resulting in version 6.1.11b*/
 /*                                                                        */
 /**************************************************************************/
 UINT _nx_secure_tls_process_record(NX_SECURE_TLS_SESSION *tls_session, NX_PACKET *packet_ptr,
@@ -579,7 +582,8 @@ NX_PACKET *decrypted_packet;
         }
 
 #ifdef NX_SECURE_KEY_CLEAR
-        if (message_type != NX_SECURE_TLS_APPLICATION_DATA)
+        if ((message_type != NX_SECURE_TLS_APPLICATION_DATA) &&
+            (status != NX_CONTINUE))
         {
             NX_SECURE_MEMSET(packet_data, 0, message_length);
         }

--- a/nx_secure/src/nx_secure_tls_process_remote_certificate.c
+++ b/nx_secure/src/nx_secure_tls_process_remote_certificate.c
@@ -31,7 +31,7 @@
 /*  FUNCTION                                               RELEASE        */
 /*                                                                        */
 /*    _nx_secure_tls_process_remote_certificate           PORTABLE C      */
-/*                                                           6.1.11       */
+/*                                                           6.1.11b      */
 /*  AUTHOR                                                                */
 /*                                                                        */
 /*    Timothy Stapko, Microsoft Corporation                               */
@@ -87,6 +87,10 @@
 /*  04-25-2022     Timothy Stapko           Modified comment(s),          */
 /*                                            removed unnecessary code,   */
 /*                                            resulting in version 6.1.11 */
+/*  02-03-2023     Tiejun Zhou              Modified comment(s),          */
+/*                                            initialized metadata for    */
+/*                                            remote certificate,         */
+/*                                            resulting in version 6.1.11b*/
 /*                                                                        */
 /**************************************************************************/
 UINT _nx_secure_tls_process_remote_certificate(NX_SECURE_TLS_SESSION *tls_session,
@@ -377,7 +381,18 @@ ULONG                cert_buf_size;
         /* Copy the certificate data to the end of the certificate buffer or use an allocated certificate. */
         certificate -> nx_secure_x509_certificate_raw_data_length = endpoint_length;
         NX_SECURE_MEMCPY(certificate->nx_secure_x509_certificate_raw_data, endpoint_raw_ptr, endpoint_length); /* Use case of memcpy is verified. */
-        
+
+        /* Assign the TLS Session metadata areas to the certificate for later use. */
+        certificate -> nx_secure_x509_public_cipher_metadata_area = tls_session -> nx_secure_public_cipher_metadata_area;
+        certificate -> nx_secure_x509_public_cipher_metadata_size = tls_session -> nx_secure_public_cipher_metadata_size;
+
+        certificate -> nx_secure_x509_hash_metadata_area = tls_session -> nx_secure_hash_mac_metadata_area;
+        certificate -> nx_secure_x509_hash_metadata_size = tls_session -> nx_secure_hash_mac_metadata_size;
+
+        /* Assign the cipher table from the parent TLS session. */
+        certificate -> nx_secure_x509_cipher_table = tls_session -> nx_secure_tls_crypto_table -> nx_secure_tls_x509_cipher_table;
+        certificate -> nx_secure_x509_cipher_table_size = tls_session -> nx_secure_tls_crypto_table -> nx_secure_tls_x509_cipher_table_size;
+
         /* Release the protection. */
         tx_mutex_put(&_nx_secure_tls_protection);
 

--- a/nx_secure/src/nx_secure_tls_send_clienthello_extensions.c
+++ b/nx_secure/src/nx_secure_tls_send_clienthello_extensions.c
@@ -497,7 +497,7 @@ UCHAR sig_algo = 0;
 /*                                                                        */
 /*    _nx_secure_tls_send_clienthello_supported_versions_extension        */
 /*                                                        PORTABLE C      */
-/*                                                           6.1          */
+/*                                                           6.1.11b      */
 /*  AUTHOR                                                                */
 /*                                                                        */
 /*    Timothy Stapko, Microsoft Corporation                               */
@@ -535,6 +535,9 @@ UCHAR sig_algo = 0;
 /*  05-19-2020     Timothy Stapko           Initial Version 6.0           */
 /*  09-30-2020     Timothy Stapko           Modified comment(s),          */
 /*                                            resulting in version 6.1    */
+/*  02-03-2023     Tiejun Zhou              Modified comment(s),          */
+/*                                            fixed compiler warnings,    */
+/*                                            resulting in version 6.1.11b*/
 /*                                                                        */
 /**************************************************************************/
 #if (NX_SECURE_TLS_TLS_1_3_ENABLED)
@@ -548,8 +551,10 @@ ULONG  offset;
 USHORT ext;
 UINT   data_length;
 UINT   id = NX_SECURE_TLS;
+#ifndef NX_SECURE_TLS_DISABLE_PROTOCOL_VERSION_DOWNGRADE
 USHORT protocol_version;
 INT    i;
+#endif /* NX_SECURE_TLS_DISABLE_PROTOCOL_VERSION_DOWNGRADE */
 
     /* Supported Versions Extension structure:
      * |     2      |         2          |      1       | <list length> |

--- a/nx_secure/src/nx_secure_tls_send_serverhello_extensions.c
+++ b/nx_secure/src/nx_secure_tls_send_serverhello_extensions.c
@@ -56,7 +56,7 @@ static UINT _nx_secure_tls_send_serverhello_psk_extension(NX_SECURE_TLS_SESSION 
 /*  FUNCTION                                               RELEASE        */
 /*                                                                        */
 /*    _nx_secure_tls_send_serverhello_extensions          PORTABLE C      */
-/*                                                           6.1.11       */
+/*                                                           6.1.11b      */
 /*  AUTHOR                                                                */
 /*                                                                        */
 /*    Timothy Stapko, Microsoft Corporation                               */
@@ -99,6 +99,9 @@ static UINT _nx_secure_tls_send_serverhello_psk_extension(NX_SECURE_TLS_SESSION 
 /*  04-25-2022     Yuxin Zhou               Modified comment(s),          */
 /*                                            removed unused code,        */
 /*                                            resulting in version 6.1.11 */
+/*  02-03-2023     Tiejun Zhou              Modified comment(s),          */
+/*                                            fixed compiler warnings,    */
+/*                                            resulting in version 6.1.11b*/
 /*                                                                        */
 /**************************************************************************/
 UINT _nx_secure_tls_send_serverhello_extensions(NX_SECURE_TLS_SESSION *tls_session,
@@ -113,9 +116,9 @@ USHORT extension_length = 0;
 USHORT total_extensions_length;
 UINT   status = NX_SUCCESS;
 
-#if defined(NX_SECURE_TLS_DISABLE_SECURE_RENEGOTIATION) && (!NX_SECURE_TLS_TLS_1_3_ENABLED)
+#if defined(NX_SECURE_TLS_DISABLE_SECURE_RENEGOTIATION) || (!NX_SECURE_TLS_TLS_1_3_ENABLED)
     NX_PARAMETER_NOT_USED(tls_session);
-#endif /* defined(NX_SECURE_TLS_DISABLE_SECURE_RENEGOTIATION) && (!NX_SECURE_TLS_TLS_1_3_ENABLED) */
+#endif /* defined(NX_SECURE_TLS_DISABLE_SECURE_RENEGOTIATION) || (!NX_SECURE_TLS_TLS_1_3_ENABLED) */
 
     if (available_size < (*packet_offset + 2u))
     {


### PR DESCRIPTION
- Initialize metadata for certificate using packet buffer
- Fix the logic to cleanup key material