### PR TITLE
Release MQTT client mutex when "MQTT NOT CONNECTED"

### DIFF
--- a/addons/azure_iot/nx_azure_iot.c
+++ b/addons/azure_iot/nx_azure_iot.c
@@ -420,6 +420,7 @@ UINT status;
     /* Do nothing if the client is not connected.  */
     if (client_ptr -> nxd_mqtt_client_state != NXD_MQTT_CLIENT_STATE_CONNECTED)
     {
+        tx_mutex_put(client_ptr -> nxd_mqtt_client_mutex_ptr);
         LogError(LogLiteralArgs("MQTT NOT CONNECTED"));
         return(NX_AZURE_IOT_DISCONNECTED);
     }


### PR DESCRIPTION
Release MQTT client mutex when "MQTT NOT CONNECTED" error occurs to avoid deadlock on reconnection.